### PR TITLE
Advanced settings for img2img and inpaint modes

### DIFF
--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -166,13 +166,6 @@
               <sp-label class="value">{{ inpaintSuperSampling / 20 }}</sp-label>
             </sp-label>
           </sp-slider>
-
-          <sp-slider v-show="currentMode === 'inpaint'" v-model-custom-element="inpaintPadding" min="0" max="32" show-value="false">
-            <sp-label slot="label" class="label">
-              Padding
-              <sp-label class="value">{{ inpaintPadding * 8 }}</sp-label>
-            </sp-label>
-          </sp-slider>
         </div>
       </div>
 
@@ -210,6 +203,10 @@
         {{ getTextForGenerateButton(false) }}
         <span v-show="isGenerating" class="generate-button__progressbar" :style="{ width: progress + '%' }"></span>
       </sp-button>
+
+      <sp-detail size="M" class="generated-size">
+        Generated size : {{ getTextForGenerateSize() }}
+      </sp-detail>
     </div> <!-- .form -->
 
     <div>
@@ -271,7 +268,6 @@ export default {
       cfgScale: 7,
       denoisingStrength: 75,
       inpaintSuperSampling: 20,
-      inpaintPadding: 4,
       imagesNumber: 4,
       styles: [],
 
@@ -821,6 +817,9 @@ export default {
       }
       return isGenerateMoreButton ? 'Generate More' : 'Generate';
     },
+    getTextForGenerateSize() {
+      return `${this.getSizeForGeneratingImage.width}x${this.getSizeForGeneratingImage.height}`;
+    },
   },
 
 };
@@ -832,6 +831,10 @@ export default {
     width: 100%;
     position: relative;
     overflow: hidden;
+  }
+
+  .generated-size {
+    text-align: center;
   }
 
   .generate-button__progressbar {

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -174,13 +174,13 @@
 
           <sp-slider
             v-model-custom-element="inpaintDimension"
-            :min="Math.round(0 / inpaintDimensionStep)"
+            :min="Math.round((448 - inpaintDimensionStep) / inpaintDimensionStep)"
             :max="Math.round(2560 / inpaintDimensionStep)"
             show-value="false"
           >
             <sp-label slot="label" class="label">
-              Dimension (long side)
-              <sp-label class="value">{{ inpaintDimension === 0 ? 'auto' : Math.round(inpaintDimension * inpaintDimensionStep) }}</sp-label>
+              Dimension min.
+              <sp-label class="value">{{ inpaintDimension === (448 - inpaintDimensionStep) / inpaintDimensionStep ? 'auto' : Math.round(inpaintDimension * inpaintDimensionStep) }}</sp-label>
             </sp-label>
           </sp-slider>
         </div>
@@ -287,7 +287,7 @@ export default {
       inpaintSuperSamplingStep: 0.05,
       inpaintSuperSampling: 20, // 1 / inpaintSuperSamplingStep
       inpaintDimensionStep: 32,
-      inpaintDimension: 0, // auto
+      inpaintDimension: 13, // auto = (448 - inpaintDimensionStep) / inpaintDimensionStep
       imagesNumber: 4,
       styles: [],
 

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -160,15 +160,10 @@
         </sp-heading>
 
         <div v-if="showCollapsedSection.inpaintAdvancedSettings">
-          <sp-slider
-            v-model-custom-element="inpaintDimension"
-            :min="Math.round((448 - inpaintDimensionStep) / inpaintDimensionStep)"
-            :max="Math.round(2560 / inpaintDimensionStep)"
-            show-value="false"
-          >
+          <sp-slider v-model-custom-element="inpaintDimension" min="480" max="2560" show-value="false" step="32">
             <sp-label slot="label" class="label">
               Render dimension min.
-              <sp-label class="value">{{ inpaintDimension === (448 - inpaintDimensionStep) / inpaintDimensionStep ? 'auto' : Math.round(inpaintDimension * inpaintDimensionStep) }}</sp-label>
+              <sp-label class="value">{{ inpaintDimension === 480 ? 'auto' : inpaintDimension }}</sp-label>
             </sp-label>
           </sp-slider>
         </div>
@@ -272,8 +267,7 @@ export default {
       steps: 20,
       cfgScale: 7,
       denoisingStrength: 75,
-      inpaintDimensionStep: 32,
-      inpaintDimension: 13, // auto = (448 - inpaintDimensionStep) / inpaintDimensionStep
+      inpaintDimension: 480, // auto
       imagesNumber: 4,
       styles: [],
 
@@ -319,6 +313,22 @@ export default {
       if (!width || !height) {
         width = 512;
         height = 512;
+      }
+
+      if (this.inpaintDimension > 480) { // 480 = auto value
+        const biggestValue = width > height ? width : height;
+        const ratio = this.inpaintDimension / biggestValue;
+
+        if (biggestValue < this.inpaintDimension) {
+          if (width > height) {
+            height = Math.round(height * ratio);
+            width = this.inpaintDimension;
+          }
+          else {
+            width = Math.round(width * ratio);
+            height = this.inpaintDimension;
+          }
+        }
       }
 
       if (width !== height || this.currentMode !== 'txt2img') {

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -171,6 +171,18 @@
               <sp-label class="value">{{ Math.round(inpaintSuperSampling * 100 * inpaintSuperSamplingStep) / 100 }}</sp-label>
             </sp-label>
           </sp-slider>
+
+          <sp-slider
+            v-model-custom-element="inpaintDimension"
+            :min="Math.round(0 / inpaintDimensionStep)"
+            :max="Math.round(2560 / inpaintDimensionStep)"
+            show-value="false"
+          >
+            <sp-label slot="label" class="label">
+              Dimension (long side)
+              <sp-label class="value">{{ inpaintDimension === 0 ? 'auto' : Math.round(inpaintDimension * inpaintDimensionStep) }}</sp-label>
+            </sp-label>
+          </sp-slider>
         </div>
       </div>
 
@@ -274,6 +286,8 @@ export default {
       denoisingStrength: 75,
       inpaintSuperSamplingStep: 0.05,
       inpaintSuperSampling: 20, // 1 / inpaintSuperSamplingStep
+      inpaintDimensionStep: 32,
+      inpaintDimension: 0, // auto
       imagesNumber: 4,
       styles: [],
 

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -149,7 +149,7 @@
         </sp-label>
       </sp-slider>
 
-      <div v-show="currentMode !== 'txt2img'" class="form__collapsed-section">
+      <div v-show="currentMode === 'inpaint'" class="form__collapsed-section">
         <sp-heading v-show="currentMode === 'img2img'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
           <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
           Img2img Advanced Settings
@@ -161,25 +161,13 @@
 
         <div v-if="showCollapsedSection.inpaintAdvancedSettings">
           <sp-slider
-            v-model-custom-element="inpaintSuperSampling"
-            :min="Math.round(1 / inpaintSuperSamplingStep)"
-            :max="Math.round(4 / inpaintSuperSamplingStep)"
-            show-value="false"
-          >
-            <sp-label slot="label" class="label">
-              Supersampling
-              <sp-label class="value">{{ Math.round(inpaintSuperSampling * 100 * inpaintSuperSamplingStep) / 100 }}</sp-label>
-            </sp-label>
-          </sp-slider>
-
-          <sp-slider
             v-model-custom-element="inpaintDimension"
             :min="Math.round((448 - inpaintDimensionStep) / inpaintDimensionStep)"
             :max="Math.round(2560 / inpaintDimensionStep)"
             show-value="false"
           >
             <sp-label slot="label" class="label">
-              Dimension min.
+              Render dimension min.
               <sp-label class="value">{{ inpaintDimension === (448 - inpaintDimensionStep) / inpaintDimensionStep ? 'auto' : Math.round(inpaintDimension * inpaintDimensionStep) }}</sp-label>
             </sp-label>
           </sp-slider>
@@ -284,8 +272,6 @@ export default {
       steps: 20,
       cfgScale: 7,
       denoisingStrength: 75,
-      inpaintSuperSamplingStep: 0.05,
-      inpaintSuperSampling: 20, // 1 / inpaintSuperSamplingStep
       inpaintDimensionStep: 32,
       inpaintDimension: 13, // auto = (448 - inpaintDimensionStep) / inpaintDimensionStep
       imagesNumber: 4,
@@ -333,11 +319,6 @@ export default {
       if (!width || !height) {
         width = 512;
         height = 512;
-      }
-
-      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== (1 / this.inpaintSuperSamplingStep)) {
-        width = Math.round(width * (this.inpaintSuperSampling * this.inpaintSuperSamplingStep));
-        height = Math.round(height * (this.inpaintSuperSampling * this.inpaintSuperSamplingStep));
       }
 
       if (width !== height || this.currentMode !== 'txt2img') {

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -152,11 +152,11 @@
       <div v-show="currentMode !== 'txt2img'" class="form__collapsed-section">
         <sp-heading v-show="currentMode === 'img2img'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
           <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
-          Img2img advanced Settings
+          Img2img Advanced Settings
         </sp-heading>
         <sp-heading v-show="currentMode === 'inpaint'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
           <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
-          Inpaint advanced Settings
+          Inpaint Advanced Settings
         </sp-heading>
 
         <div v-if="showCollapsedSection.inpaintAdvancedSettings">
@@ -317,11 +317,6 @@ export default {
       if (!width || !height) {
         width = 512;
         height = 512;
-      }
-
-      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== 20) {
-        width = Math.round(width * (this.inpaintSuperSampling / 20));
-        height = Math.round(height * (this.inpaintSuperSampling / 20));
       }
 
       if (width !== height || this.currentMode !== 'txt2img') {

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -160,10 +160,15 @@
         </sp-heading>
 
         <div v-if="showCollapsedSection.inpaintAdvancedSettings">
-          <sp-slider v-model-custom-element="inpaintSuperSampling" min="20" max="80" show-value="false">
+          <sp-slider
+            v-model-custom-element="inpaintSuperSampling"
+            :min="Math.round(1 / inpaintSuperSamplingStep)"
+            :max="Math.round(4 / inpaintSuperSamplingStep)"
+            show-value="false"
+          >
             <sp-label slot="label" class="label">
               Supersampling
-              <sp-label class="value">{{ inpaintSuperSampling / 20 }}</sp-label>
+              <sp-label class="value">{{ Math.round(inpaintSuperSampling * 100 * inpaintSuperSamplingStep) / 100 }}</sp-label>
             </sp-label>
           </sp-slider>
         </div>
@@ -267,7 +272,8 @@ export default {
       steps: 20,
       cfgScale: 7,
       denoisingStrength: 75,
-      inpaintSuperSampling: 20,
+      inpaintSuperSamplingStep: 0.05,
+      inpaintSuperSampling: 20, // 1 / inpaintSuperSamplingStep
       imagesNumber: 4,
       styles: [],
 
@@ -315,9 +321,9 @@ export default {
         height = 512;
       }
 
-      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== 20) {
-        width = Math.round(width * (this.inpaintSuperSampling / 20));
-        height = Math.round(height * (this.inpaintSuperSampling / 20));
+      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== (1 / this.inpaintSuperSamplingStep)) {
+        width = Math.round(width * (this.inpaintSuperSampling * this.inpaintSuperSamplingStep));
+        height = Math.round(height * (this.inpaintSuperSampling * this.inpaintSuperSamplingStep));
       }
 
       if (width !== height || this.currentMode !== 'txt2img') {

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -149,26 +149,6 @@
         </sp-label>
       </sp-slider>
 
-      <div v-show="currentMode === 'inpaint'" class="form__collapsed-section">
-        <sp-heading v-show="currentMode === 'img2img'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
-          <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
-          Img2img Advanced Settings
-        </sp-heading>
-        <sp-heading v-show="currentMode === 'inpaint'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
-          <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
-          Inpaint Advanced Settings
-        </sp-heading>
-
-        <div v-if="showCollapsedSection.inpaintAdvancedSettings">
-          <sp-slider v-model-custom-element="inpaintDimension" min="480" max="2560" show-value="false" step="32">
-            <sp-label slot="label" class="label">
-              Render dimension min.
-              <sp-label class="value">{{ inpaintDimension === 480 ? 'auto' : inpaintDimension }}</sp-label>
-            </sp-label>
-          </sp-slider>
-        </div>
-      </div>
-
       <div class="form__collapsed-section">
         <sp-heading size="XS" @click="toggleCollapsedSection('advancedSettings')">
           <span>{{ showCollapsedSection.advancedSettings ? '▼' : '▶' }}</span>
@@ -180,6 +160,13 @@
             <sp-label slot="label" class="label">
               Number of images
               <sp-label class="value">{{ imagesNumber }}</sp-label>
+            </sp-label>
+          </sp-slider>
+
+          <sp-slider v-model-custom-element="inpaintDimension" min="480" max="2560" show-value="false" step="32">
+            <sp-label slot="label" class="label">
+              Render dimension min.
+              <sp-label class="value">{{ inpaintDimension === 480 ? 'auto' : inpaintDimension }}</sp-label>
             </sp-label>
           </sp-slider>
 

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -319,6 +319,11 @@ export default {
         height = 512;
       }
 
+      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== 20) {
+        width = Math.round(width * (this.inpaintSuperSampling / 20));
+        height = Math.round(height * (this.inpaintSuperSampling / 20));
+      }
+
       if (width !== height || this.currentMode !== 'txt2img') {
         width = 8 * Math.round(width / 8);
         height = 8 * Math.round(height / 8);

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -149,6 +149,33 @@
         </sp-label>
       </sp-slider>
 
+      <div v-show="currentMode !== 'txt2img'" class="form__collapsed-section">
+        <sp-heading v-show="currentMode === 'img2img'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
+          <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
+          Img2img advanced Settings
+        </sp-heading>
+        <sp-heading v-show="currentMode === 'inpaint'" size="XS" @click="toggleCollapsedSection('inpaintAdvancedSettings')">
+          <span>{{ showCollapsedSection.inpaintAdvancedSettings ? '▼' : '▶' }}</span>
+          Inpaint advanced Settings
+        </sp-heading>
+
+        <div v-if="showCollapsedSection.inpaintAdvancedSettings">
+          <sp-slider v-model-custom-element="inpaintSuperSampling" min="20" max="80" show-value="false">
+            <sp-label slot="label" class="label">
+              Supersampling
+              <sp-label class="value">{{ inpaintSuperSampling / 20 }}</sp-label>
+            </sp-label>
+          </sp-slider>
+
+          <sp-slider v-show="currentMode === 'inpaint'" v-model-custom-element="inpaintPadding" min="0" max="32" show-value="false">
+            <sp-label slot="label" class="label">
+              Padding
+              <sp-label class="value">{{ inpaintPadding * 8 }}</sp-label>
+            </sp-label>
+          </sp-slider>
+        </div>
+      </div>
+
       <div class="form__collapsed-section">
         <sp-heading size="XS" @click="toggleCollapsedSection('advancedSettings')">
           <span>{{ showCollapsedSection.advancedSettings ? '▼' : '▶' }}</span>
@@ -243,6 +270,8 @@ export default {
       steps: 20,
       cfgScale: 7,
       denoisingStrength: 75,
+      inpaintSuperSampling: 20,
+      inpaintPadding: 4,
       imagesNumber: 4,
       styles: [],
 
@@ -268,7 +297,7 @@ export default {
       loadingModelsStatus: '',
       textareaInputDebounceTimer: null,
 
-      showCollapsedSection: {advancedSettings: false, styles: false},
+      showCollapsedSection: {advancedSettings: false, styles: false, inpaintAdvancedSettings: false},
       isSaveImagesLocally: false,
     };
   },
@@ -288,6 +317,11 @@ export default {
       if (!width || !height) {
         width = 512;
         height = 512;
+      }
+
+      if (this.currentMode !== 'txt2img' && this.inpaintSuperSampling !== 20) {
+        width = Math.round(width * (this.inpaintSuperSampling / 20));
+        height = Math.round(height * (this.inpaintSuperSampling / 20));
       }
 
       if (width !== height || this.currentMode !== 'txt2img') {

--- a/src/constantsMixin.js
+++ b/src/constantsMixin.js
@@ -1,0 +1,16 @@
+// separate variables are for using inside data() because of the Vue lifecycle (Vue calls data() BEFORE computed)
+// mixin with computed are for using inside templates (<html>)
+
+export const EXPORT_MASK_FILENAME = 'stableart_exported_mask.png';
+export const DISABLED_MINIMUM_DIMENSION = 448;
+
+export const constantsMixin = {
+  computed: {
+    getConstants() {
+      return {
+        EXPORT_MASK_FILENAME,
+        DISABLED_MINIMUM_DIMENSION,
+      };
+    },
+  },
+};

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -451,66 +451,37 @@ export default {
       this.generatedImagePosition = {left: leftPosition, top: topPosition};
 
       if (this.currentMode === 'inpaint') {
-        const absoluteMinDimension = 448; // don't let any dimension fall below this value
-        const autoDimension = 512; // use this value for 'auto'
-
         const inpaintAreaWidth = rightPosition - leftPosition;
-        const inpaintAreaHeight = bottomPosition - topPosition;
-
-        const inpaintRatio = inpaintAreaWidth / inpaintAreaHeight;
-        const inpaintDimension = this.inpaintDimension > (448 - this.inpaintDimensionStep) / this.inpaintDimensionStep // slider on 'auto'
-          ? Math.round((this.inpaintDimension * this.inpaintDimensionStep))
-          : autoDimension;
-
-        // calculate inpainting min dimensions using the long side
-        let inpaintDimensionWidth;
-        let inpaintDimensionHeight;
-        if (inpaintRatio >= 1.0) {
-          inpaintDimensionWidth = inpaintDimension;
-          inpaintDimensionHeight = Math.round(inpaintDimensionWidth / inpaintRatio);
-          if (inpaintDimensionHeight < absoluteMinDimension) {
-            inpaintDimensionHeight = absoluteMinDimension;
-          }
-        }
-        else if (inpaintRatio < 1.0) {
-          inpaintDimensionHeight = inpaintDimension;
-          inpaintDimensionWidth = Math.round(inpaintDimensionHeight * inpaintRatio);
-          if (inpaintDimensionWidth < absoluteMinDimension) {
-            inpaintDimensionWidth = absoluteMinDimension;
-          }
-        }
-
-        // handle width if needed
-        if (inpaintAreaWidth < inpaintDimensionWidth) {
-          const widthOffset = (inpaintDimensionWidth - inpaintAreaWidth) / 2;
+        if (inpaintAreaWidth < 512) {
+          const widthOffset = (512 - inpaintAreaWidth) / 2;
           const canvasWidth = maskJimpObject.bitmap.width;
 
           rightPosition += widthOffset;
           leftPosition -= widthOffset;
           if (rightPosition > canvasWidth) {
             rightPosition = canvasWidth;
-            leftPosition = canvasWidth - inpaintDimensionWidth;
+            leftPosition = canvasWidth - 512;
           }
           if (leftPosition < 0) {
             leftPosition = 0;
-            rightPosition = inpaintDimensionWidth;
+            rightPosition = 512;
           }
         }
 
-        // handle height if needed
-        if (inpaintAreaHeight < inpaintDimensionHeight) {
-          const heightOffset = (inpaintDimensionHeight - inpaintAreaHeight) / 2;
+        const inpaintAreaHeight = bottomPosition - topPosition;
+        if (inpaintAreaHeight < 512) {
+          const heightOffset = (512 - inpaintAreaHeight) / 2;
           const canvasHeight = maskJimpObject.bitmap.height;
 
           bottomPosition += heightOffset;
           topPosition -= heightOffset;
           if (bottomPosition > canvasHeight) {
             bottomPosition = canvasHeight;
-            topPosition = canvasHeight - inpaintDimensionHeight;
+            topPosition = canvasHeight - 512;
           }
           if (topPosition < 0) {
             topPosition = 0;
-            bottomPosition = inpaintDimensionHeight;
+            bottomPosition = 512;
           }
         }
 

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -154,7 +154,7 @@ export default {
           mask_blur: 4,
           inpainting_fill: this.currentMode === 'inpaint' ? 1 : 0, // 1 == original; 2 == latent noise
           inpaint_full_res: true,
-          inpaint_full_res_padding: 32,
+          inpaint_full_res_padding: Number(this.inpaintPadding * 8),
           inpainting_mask_invert: 0,
           prompt: this.prompt,
           styles: this.getCheckedStyles,

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -460,17 +460,21 @@ export default {
         // into account the ratio that will be applied in getSizeForGeneratingImage()
         if (this.inpaintDimension > 480) { // not auto inpaint dimension
           if (inpaintAreaWidth > inpaintAreaHeight
+            && inpaintAreaWidth < this.inpaintDimension
             && inpaintAreaHeight * (this.inpaintDimension / inpaintAreaWidth) < 512) {
-            inpaintMinSize.height *= 512 / this.inpaintDimension; // ensure 512 minimum height
+            inpaintMinSize.height *= Math.max(512, inpaintAreaWidth) / this.inpaintDimension; // ensure 512 minimum height
           }
-          else if (inpaintAreaWidth > inpaintAreaHeight) {
+          else if (inpaintAreaWidth > inpaintAreaHeight
+            && inpaintAreaWidth < this.inpaintDimension) {
             inpaintMinSize.height *= inpaintAreaHeight / inpaintAreaWidth; // reduced minimum height
           }
           else if (inpaintAreaHeight > inpaintAreaWidth
+            && inpaintAreaHeight < this.inpaintDimension
             && inpaintAreaWidth * (this.inpaintDimension / inpaintAreaHeight) < 512) {
-            inpaintMinSize.width *= 512 / this.inpaintDimension; // ensure 512 minimum width
+            inpaintMinSize.width *= Math.max(512, inpaintAreaHeight) / this.inpaintDimension; // ensure 512 minimum height
           }
-          else if (inpaintAreaHeight > inpaintAreaWidth) {
+          else if (inpaintAreaHeight > inpaintAreaWidth
+            && inpaintAreaHeight < this.inpaintDimension) {
             inpaintMinSize.width *= inpaintAreaWidth / inpaintAreaHeight; // reduced minimum width
           }
         }

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -154,7 +154,7 @@ export default {
           mask_blur: 4,
           inpainting_fill: this.currentMode === 'inpaint' ? 1 : 0, // 1 == original; 2 == latent noise
           inpaint_full_res: true,
-          inpaint_full_res_padding: Number(this.inpaintPadding * 8),
+          inpaint_full_res_padding: 32,
           inpainting_mask_invert: 0,
           prompt: this.prompt,
           styles: this.getCheckedStyles,

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -452,36 +452,60 @@ export default {
 
       if (this.currentMode === 'inpaint') {
         const inpaintAreaWidth = rightPosition - leftPosition;
-        if (inpaintAreaWidth < 512) {
-          const widthOffset = (512 - inpaintAreaWidth) / 2;
+        const inpaintAreaHeight = bottomPosition - topPosition;
+
+        const inpaintMinSize = {width: 512, height: 512};
+
+        // if inpaintDimension is used, alter inpaintMinSize.width or height to take
+        // into account the ratio that will be applied in getSizeForGeneratingImage()
+        if (this.inpaintDimension > 480) { // not auto inpaint dimension
+          if (inpaintAreaWidth > inpaintAreaHeight
+            && inpaintAreaHeight * (this.inpaintDimension / inpaintAreaWidth) < 512) {
+            inpaintMinSize.height *= 512 / this.inpaintDimension; // ensure 512 minimum height
+          }
+          else if (inpaintAreaWidth > inpaintAreaHeight) {
+            inpaintMinSize.height *= inpaintAreaHeight / inpaintAreaWidth; // reduced minimum height
+          }
+          else if (inpaintAreaHeight > inpaintAreaWidth
+            && inpaintAreaWidth * (this.inpaintDimension / inpaintAreaHeight) < 512) {
+            inpaintMinSize.width *= 512 / this.inpaintDimension; // ensure 512 minimum width
+          }
+          else if (inpaintAreaHeight > inpaintAreaWidth) {
+            inpaintMinSize.width *= inpaintAreaWidth / inpaintAreaHeight; // reduced minimum width
+          }
+        }
+
+        // enforce inpaint minimum width
+        if (inpaintAreaWidth < inpaintMinSize.width) {
+          const widthOffset = (inpaintMinSize.width - inpaintAreaWidth) / 2;
           const canvasWidth = maskJimpObject.bitmap.width;
 
           rightPosition += widthOffset;
           leftPosition -= widthOffset;
           if (rightPosition > canvasWidth) {
             rightPosition = canvasWidth;
-            leftPosition = canvasWidth - 512;
+            leftPosition = canvasWidth - inpaintMinSize.width;
           }
           if (leftPosition < 0) {
             leftPosition = 0;
-            rightPosition = 512;
+            rightPosition = inpaintMinSize.width;
           }
         }
 
-        const inpaintAreaHeight = bottomPosition - topPosition;
-        if (inpaintAreaHeight < 512) {
-          const heightOffset = (512 - inpaintAreaHeight) / 2;
+        // enforce inpaint minimum height
+        if (inpaintAreaHeight < inpaintMinSize.height) {
+          const heightOffset = (inpaintMinSize.height - inpaintAreaHeight) / 2;
           const canvasHeight = maskJimpObject.bitmap.height;
 
           bottomPosition += heightOffset;
           topPosition -= heightOffset;
           if (bottomPosition > canvasHeight) {
             bottomPosition = canvasHeight;
-            topPosition = canvasHeight - 512;
+            topPosition = canvasHeight - inpaintMinSize.height;
           }
           if (topPosition < 0) {
             topPosition = 0;
-            bottomPosition = 512;
+            bottomPosition = inpaintMinSize.height;
           }
         }
 

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -451,17 +451,18 @@ export default {
       this.generatedImagePosition = {left: leftPosition, top: topPosition};
 
       if (this.currentMode === 'inpaint') {
-        const absoluteMinDimension = 448;
-        const autoDimension = 512;
+        const absoluteMinDimension = 448; // don't let any dimension fall below this value
+        const autoDimension = 512; // use this value for 'auto'
 
         const inpaintAreaWidth = rightPosition - leftPosition;
         const inpaintAreaHeight = bottomPosition - topPosition;
 
         const inpaintRatio = inpaintAreaWidth / inpaintAreaHeight;
-        const inpaintDimension = this.inpaintDimension > (448 - this.inpaintDimensionStep) / this.inpaintDimensionStep // auto
+        const inpaintDimension = this.inpaintDimension > (448 - this.inpaintDimensionStep) / this.inpaintDimensionStep // slider on 'auto'
           ? Math.round((this.inpaintDimension * this.inpaintDimensionStep))
           : autoDimension;
 
+        // calculate inpainting min dimensions using the long side
         let inpaintDimensionWidth;
         let inpaintDimensionHeight;
         if (inpaintRatio >= 1.0) {
@@ -479,6 +480,7 @@ export default {
           }
         }
 
+        // handle width if needed
         if (inpaintAreaWidth < inpaintDimensionWidth) {
           const widthOffset = (inpaintDimensionWidth - inpaintAreaWidth) / 2;
           const canvasWidth = maskJimpObject.bitmap.width;
@@ -495,6 +497,7 @@ export default {
           }
         }
 
+        // handle height if needed
         if (inpaintAreaHeight < inpaintDimensionHeight) {
           const heightOffset = (inpaintDimensionHeight - inpaintAreaHeight) / 2;
           const canvasHeight = maskJimpObject.bitmap.height;

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -451,37 +451,63 @@ export default {
       this.generatedImagePosition = {left: leftPosition, top: topPosition};
 
       if (this.currentMode === 'inpaint') {
+        const absoluteMinDimension = 448;
+        const autoDimension = 512;
+
         const inpaintAreaWidth = rightPosition - leftPosition;
-        if (inpaintAreaWidth < 512) {
-          const widthOffset = (512 - inpaintAreaWidth) / 2;
+        const inpaintAreaHeight = bottomPosition - topPosition;
+
+        const inpaintRatio = inpaintAreaWidth / inpaintAreaHeight;
+        const inpaintDimension = this.inpaintDimension > (448 - this.inpaintDimensionStep) / this.inpaintDimensionStep // auto
+          ? Math.round((this.inpaintDimension * this.inpaintDimensionStep))
+          : autoDimension;
+
+        let inpaintDimensionWidth;
+        let inpaintDimensionHeight;
+        if (inpaintRatio >= 1.0) {
+          inpaintDimensionWidth = inpaintDimension;
+          inpaintDimensionHeight = Math.round(inpaintDimensionWidth / inpaintRatio);
+          if (inpaintDimensionHeight < absoluteMinDimension) {
+            inpaintDimensionHeight = absoluteMinDimension;
+          }
+        }
+        else if (inpaintRatio < 1.0) {
+          inpaintDimensionHeight = inpaintDimension;
+          inpaintDimensionWidth = Math.round(inpaintDimensionHeight * inpaintRatio);
+          if (inpaintDimensionWidth < absoluteMinDimension) {
+            inpaintDimensionWidth = absoluteMinDimension;
+          }
+        }
+
+        if (inpaintAreaWidth < inpaintDimensionWidth) {
+          const widthOffset = (inpaintDimensionWidth - inpaintAreaWidth) / 2;
           const canvasWidth = maskJimpObject.bitmap.width;
 
           rightPosition += widthOffset;
           leftPosition -= widthOffset;
           if (rightPosition > canvasWidth) {
             rightPosition = canvasWidth;
-            leftPosition = canvasWidth - 512;
+            leftPosition = canvasWidth - inpaintDimensionWidth;
           }
           if (leftPosition < 0) {
             leftPosition = 0;
-            rightPosition = 512;
+            rightPosition = inpaintDimensionWidth;
           }
         }
 
-        const inpaintAreaHeight = bottomPosition - topPosition;
-        if (inpaintAreaHeight < 512) {
-          const heightOffset = (512 - inpaintAreaHeight) / 2;
+        if (inpaintAreaHeight < inpaintDimensionHeight) {
+          const heightOffset = (inpaintDimensionHeight - inpaintAreaHeight) / 2;
           const canvasHeight = maskJimpObject.bitmap.height;
 
           bottomPosition += heightOffset;
           topPosition -= heightOffset;
           if (bottomPosition > canvasHeight) {
             bottomPosition = canvasHeight;
-            topPosition = canvasHeight - 512;
+            topPosition = canvasHeight - inpaintDimensionHeight;
           }
           if (topPosition < 0) {
             topPosition = 0;
-            bottomPosition = 512;
+            bottomPosition = inpaintDimensionHeight;
           }
         }
 


### PR DESCRIPTION
I propose to add a new collapsible tab "Img2img/Inpaint Advanced Settings". It is collapsed by default, and visible only if the mode is img2img or inpaint : 

![image](https://user-images.githubusercontent.com/15424198/218083507-4c18291e-f7e5-4404-a54b-331ea877408a.png) ![image](https://user-images.githubusercontent.com/15424198/218083447-3e37ed03-322e-4765-9fcc-948ec0180a3a.png)

In the advanced settings I added support for :  
 - Padding : corresponding to "Only masked padding, pixels" of Auto1111 inpainting option . This allow the inpainting to fetch more context from the original image when needed.
   - The slider is set to : min 0, max 256, default 32, step 8.
 - Supersampling : this allow to increase the generating width & height requested, to produce a more detailed image in some cases. And it can also be useful with higher padding settings. For example with the minimum 512 inpainting size, if you set the supersampling to 1.5 the generated image will be 768 then downscaled before beeing sent. This allow the same use as in Auto1111 interface when you set a big width & height when inpainting a small region.
   - The slider is set to : min 1.0, max 4.0, default 1.0, step 0.05.

The default values are set so the plugin behavior is the same as before.