### PR TITLE
Add ControlNet tile model handling to img2img and inpaint modes

### DIFF
--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -332,12 +332,27 @@ export default {
       imagesNumber: 4,
       styles: [],
 
-      cnModes: ['disabled', 'tile'],
+      cnModes: ['disabled', 'tile', 'openface', 'openpose', 'lineart', 'scribble'],
       cnMode: 'disabled',
       cnWeight: 100,
       cnGuidanceStart: 0,
       cnGuidanceEnd: 100,
-      cnModel: 'control_v11f1e_sd15_tile_fp16',
+      cnModules: {
+        disabled: undefined,
+        tile: undefined,
+        lineart: 'lineart_coarse',
+        openpose: 'openpose_full',
+        openface: 'openpose_faceonly',
+        scribble: 'pidinet_sketch',
+      },
+      cnModels: {
+        disabled: undefined,
+        tile: 'control_v11f1e_sd15_tile_fp16',
+        lineart: 'control_v11p_sd15_lineart_fp16',
+        openpose: 'control_v11p_sd15_openpose_fp16',
+        openface: 'control_v11p_sd15_openpose_fp16',
+        scribble: 'control_v11p_sd15_scribble_fp16',
+      },
 
       generatedImages: [],
       currentGeneratedImageIndex: 0,
@@ -653,9 +668,9 @@ export default {
 
       let resDataImages = res.data.images;
 
-      if (this.cnMode !== 'disabled') {
-        resDataImages.pop(); // last image is controlNet input image
-      }
+      // if (this.cnMode !== 'disabled') {
+      //   resDataImages.pop(); // last image is controlNet input image
+      // }
 
       if (this.isSaveImagesLocally) {
         await this.saveGeneratedImagesLocally(resDataImages, JSON.parse(res.data.info).all_seeds);

--- a/src/GenerateTab.vue
+++ b/src/GenerateTab.vue
@@ -197,6 +197,51 @@
             </sp-label>
           </sp-slider>
 
+          <div class="form__radio-buttons">
+            <sp-label slot="label">ControlNet mode</sp-label>
+
+            <sp-button
+              v-for="cnM in cnModes" :key="cnM" size="s"
+              :variant="cnMode === cnM ? 'cta' : 'primary'"
+              @click="changeRadioButton('cnMode', cnM)"
+            >
+              {{ cnM }}
+            </sp-button>
+          </div>
+
+          <sp-slider
+            v-show="cnMode !== 'disabled'"
+            v-model-custom-element="cnWeight" show-value="false" step="5"
+            min="1" max="99"
+          >
+            <sp-label slot="label" class="label">
+              Weight
+              <sp-label class="value">{{ cnWeight/100 }}</sp-label>
+            </sp-label>
+          </sp-slider>
+
+          <sp-slider
+            v-show="cnMode !== 'disabled'"
+            v-model-custom-element="cnGuidanceStart" show-value="false" step="5"
+            min="1" max="99"
+          >
+            <sp-label slot="label" class="label">
+              Guidance start
+              <sp-label class="value">{{ cnGuidanceStart/100 }}</sp-label>
+            </sp-label>
+          </sp-slider>
+
+          <sp-slider
+            v-show="cnMode !== 'disabled'"
+            v-model-custom-element="cnGuidanceEnd" show-value="false" step="5"
+            min="1" max="99"
+          >
+            <sp-label slot="label" class="label">
+              Guidance end
+              <sp-label class="value">{{ cnGuidanceEnd/100 }}</sp-label>
+            </sp-label>
+          </sp-slider>
+
           <div class="form__save-images-option">
             <sp-checkbox :checked="isSaveImagesLocally" @input="toggleIsSaveImagesLocally">
               Save generated images locally
@@ -286,6 +331,13 @@ export default {
       maximumDimension: 512,
       imagesNumber: 4,
       styles: [],
+
+      cnModes: ['disabled', 'tile'],
+      cnMode: 'disabled',
+      cnWeight: 100,
+      cnGuidanceStart: 0,
+      cnGuidanceEnd: 100,
+      cnModel: 'control_v11f1e_sd15_tile_fp16',
 
       generatedImages: [],
       currentGeneratedImageIndex: 0,
@@ -398,7 +450,11 @@ export default {
     this.currentSampler = storage.localStorage.getItem('currentSampler') || this.currentSampler;
     this.imagesNumber = storage.localStorage.getItem('imagesNumber') || this.imagesNumber;
     this.currentMode = storage.localStorage.getItem('currentMode') || this.currentMode;
+    this.denoisingStrength = storage.localStorage.getItem('denoisingStrength') || this.denoisingStrength;
     this.isSaveImagesLocally = storage.localStorage.getItem('isSaveImagesLocally') || this.isSaveImagesLocally;
+    this.cnWeight = storage.localStorage.getItem('cnWeight') || this.cnWeight;
+    this.cnGuidanceStart = storage.localStorage.getItem('cnGuidanceStart') || this.cnGuidanceStart;
+    this.cnGuidanceEnd = storage.localStorage.getItem('cnGuidanceEnd') || this.cnGuidanceEnd;
 
     this.getTempAndDataFolders();
 
@@ -596,6 +652,11 @@ export default {
       }
 
       let resDataImages = res.data.images;
+
+      if (this.cnMode !== 'disabled') {
+        resDataImages.pop(); // last image is controlNet input image
+      }
+
       if (this.isSaveImagesLocally) {
         await this.saveGeneratedImagesLocally(resDataImages, JSON.parse(res.data.info).all_seeds);
       }

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -139,6 +139,10 @@ export default {
       storage.localStorage.setItem('currentSampler', this.currentSampler);
       storage.localStorage.setItem('imagesNumber', this.imagesNumber);
       storage.localStorage.setItem('currentMode', this.currentMode);
+      storage.localStorage.setItem('denoisingStrength', this.denoisingStrength);
+      storage.localStorage.setItem('cnWeight', this.cnWeight);
+      storage.localStorage.setItem('cnGuidanceStart', this.cnGuidanceStart);
+      storage.localStorage.setItem('cnGuidanceEnd', this.cnGuidanceEnd);
 
       this.updateProgress();
 
@@ -180,7 +184,27 @@ export default {
           override_settings: {},
           sampler_index: this.currentSampler,
           include_init_images: false,
+          alwayson_scripts: {},
         };
+
+        if (this.imagesNumber > 1 && img2imgData.prompt === '') {
+          img2imgData.prompt = 'prompt'; // fake prompt to avoid batch crash
+        }
+
+        if (this.cnMode === 'tile') {
+          img2imgData.alwayson_scripts.controlnet = {
+            args: [
+              {
+                weight: this.cnWeight / 100,
+                guidance_start: this.cnGuidanceStart / 100,
+                guidance_end: this.cnGuidanceEnd / 100,
+                module: undefined,
+                pixel_perfect: false,
+                model: this.cnModel,
+              },
+            ],
+          };
+        }
 
         await this.sendData(img2imgData, 'img2img');
       }

--- a/src/maskGeneratorMixin.js
+++ b/src/maskGeneratorMixin.js
@@ -191,16 +191,16 @@ export default {
           img2imgData.prompt = 'prompt'; // fake prompt to avoid batch crash
         }
 
-        if (this.cnMode === 'tile') {
+        if (this.cnMode !== 'disabled') {
           img2imgData.alwayson_scripts.controlnet = {
             args: [
               {
                 weight: this.cnWeight / 100,
                 guidance_start: this.cnGuidanceStart / 100,
                 guidance_end: this.cnGuidanceEnd / 100,
-                module: undefined,
-                pixel_perfect: false,
-                model: this.cnModel,
+                module: this.cnModules[this.cnMode],
+                pixel_perfect: true,
+                model: this.cnModels[this.cnMode],
               },
             ],
           };


### PR DESCRIPTION
Use `alwayson_scripts` in payload to submit the img2img or inpaint image to ControlNet 'tile' model. With added controls for ControlNet weight, guidance start, and guidance end, this allow to use a much greater denoising strength when inpainting, and let the tile model handle the image coherency.

To do : 
 - [x] Add radio button to select ControlNet mode
 - [x] Add sliders to control CN weight, guidance start, guidance end
 - [x] Alter API payload
 - [x] ~~Remove unwanted returned image by CN API~~
   - The image can be  useful, left as is for now 
 - [x] Store settings locally
 - [ ] Allow multiple ControlNet modes selected at once (same settings to simplify)
 - [ ] Load controlnet modules from API on launch
 - [ ] Replace hardcoded tile model name by the correct one from the API
 - [ ] Disable ControlNet radio buttons if not found on API side
